### PR TITLE
Add Det politiska spelet feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ P3 Historia: [https://gish.github.io/deflector-disabler/feeds/p3historia.rss](ht
 USAPodden: [https://gish.github.io/deflector-disabler/feeds/usapodden.rss](https://gish.github.io/deflector-disabler/feeds/usapodden.rss)
 
 P3 Dokumentär: [https://gish.github.io/deflector-disabler/feeds/p3dokumentar.rss](https://gish.github.io/deflector-disabler/feeds/p3dokumentar.rss)
+
+Det politiska spelet: [https://gish.github.io/deflector-disabler/feeds/det-politiska-spelet.rss](https://gish.github.io/deflector-disabler/feeds/det-politiska-spelet.rss)
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { handler } from "./handler";
 
 const database = new DatabaseSync("./database.sql");
 createTables(database, false);
-(async () => await addPrograms(programs, database))();
-
-handler(new Date(), database, "./feeds");
+(async () => {
+  await addPrograms(programs, database);
+  process.exitCode = await handler(new Date(), database, "./feeds");
+})();

--- a/src/programs.ts
+++ b/src/programs.ts
@@ -22,4 +22,9 @@ export const programs: Program[] = [
 
     lastUpdated: new Date("2025-04-01").getTime(),
   },
+  {
+    srId: 4743,
+    title: "Det politiska spelet",
+    lastUpdated: new Date("2014-10-24").getTime(),
+  },
 ];


### PR DESCRIPTION
Add SR program 4743 (Det politiska spelet) to the program list and publish its generated feed.

Also fix a race in main.ts where addPrograms was not awaited before handler ran, so a newly added program's DB row (and slug) was not yet written when the feed was generated -- the feed only appeared on a second run. Await seeding before generating, and propagate handler's exit code so write failures fail the CI step.